### PR TITLE
Add drag-to-refresh handling

### DIFF
--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { Ionicons } from "@expo/vector-icons";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { StyleSheet, View, Text, ScrollView, Image } from "react-native";
+import { StyleSheet, View, Text, ScrollView, RefreshControl } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import FileList from "../components/FileList";
 import FileViewButton from "../components/FileViewButton";
 import FileCard from "../components/FileCard";
-import { FileCardType, FileListType, FolderCardType } from "../types/FileTypes";
+import { FileCardType, FolderCardType } from "../types/FileTypes";
 import FolderContentScreen, { RootStackParamList }  from "../components/FolderContentScreen";
 import Colors from "../utils/Colors";
 import { getFolderContent, searchLatestFiles} from "../utils/ServerRequests";
@@ -19,37 +19,37 @@ enum FileView {
 }
 
 
-interface TimeGroupedFiles {
-    [lastModified: string]: FileCardType[];
-}
-
 
 const FilesTabScreen = () => {
     const [fileView, setFileView] = useState<FileView>(FileView.Activity);
-    const [timeGroupedFiles, setTimeGroupedFiles] = useState<TimeGroupedFiles>();
     const [allFolders, setAllFolders] = useState<FolderCardType[]>( [] as FolderCardType[]);
     const [allFiles, setAllFiles] = useState<FileCardType[]>( [] as FileCardType[]);
     const [latestFiles, setLatestFiles] = useState<FileCardType[]>( [] as FileCardType[]);
 
-
-    useEffect(() => {
-        const fetchFolderContent = async () => {
-            const content = await getFolderContent("/remote.php/dav/files/testuser/");
-            if (content) {
-                setAllFiles(content.files);
-                setAllFolders(content.folders);
-            }
-        };
-        const fetchLatestFiles = async () => {
-            const results = await searchLatestFiles();
-            if (results) {
-                setLatestFiles(results);
-            }
-        };
+    const onRefresh = useCallback(() => {
         fetchFolderContent();
         fetchLatestFiles();
     }, []);
 
+    const fetchFolderContent = async () => {
+        const content = await getFolderContent("/remote.php/dav/files/testuser/");
+        if (content) {
+            setAllFiles(content.files);
+            setAllFolders(content.folders);
+        }
+    };
+    
+    const fetchLatestFiles = async () => {
+        const results = await searchLatestFiles();
+        if (results) {
+            setLatestFiles(results);
+        }
+    };
+
+    useEffect(() => {
+        fetchFolderContent();
+        fetchLatestFiles();
+    }, []);
 
     const toggleFileView = () => {
         setFileView(fileView === FileView.Courses ? FileView.Activity : FileView.Courses);
@@ -58,11 +58,7 @@ const FilesTabScreen = () => {
     const renderFileListSection = (title: string, files: FileCardType[]) => (
         <View style={styles.fileActivitySection}>
             <Text style={styles.fileActivityTime}>{title}:</Text>
-            {
-                files.map((file: FileCardType, idx: number) => {
-                    return <FileCard key={idx} {...file} />
-                })
-            }
+            <FileList folders={[]} files={files} />
         </View>
     );
 
@@ -101,7 +97,12 @@ const FilesTabScreen = () => {
         }
 
         return (
-            <ScrollView style={styles.timeBasedFileActivities}>
+            <ScrollView
+                style={styles.timeBasedFileActivities}
+                refreshControl={
+                    <RefreshControl refreshing={false} onRefresh={onRefresh} />
+                }
+            >
                 {lastThreeHoursFiles.length > 0 ? renderFileListSection("Letzte 3 Stunden", lastThreeHoursFiles) : null}
                 {todayFiles.length > 0 ? renderFileListSection("Heute", todayFiles) : null}
                 {thisWeekFiles.length > 0 ? renderFileListSection("Diese Woche", thisWeekFiles) : null}
@@ -143,7 +144,12 @@ const FilesTabScreen = () => {
                 {
                     fileView === FileView.Activity ? fileTimeCategorization()
                     : ( 
-                        <ScrollView style={styles.courseFolderSection}>
+                        <ScrollView
+                            style={styles.courseFolderSection}
+                            refreshControl={
+                                <RefreshControl refreshing={false} onRefresh={onRefresh} />
+                            }
+                        >
                             <FileList folders={allFolders} files={allFiles}/>
                         </ScrollView>
                     )

--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -62,7 +62,7 @@ const FilesTabScreen = () => {
     const renderFileListSection = (title: string, files: FileCardType[]) => (
         <View style={styles.fileActivitySection}>
             <Text style={styles.fileActivityTime}>{title}:</Text>
-            <FileList folders={[]} files={files} />
+            <FileList folders={[]} files={files} refreshFunction={fetchAllData}/>
         </View>
     );
 
@@ -154,7 +154,7 @@ const FilesTabScreen = () => {
                                 <RefreshControl refreshing={false} onRefresh={onRefresh} />
                             }
                         >
-                            <FileList folders={allFolders} files={allFiles}/>
+                            <FileList folders={allFolders} files={allFiles} refreshFunction={fetchAllData}/>
                         </ScrollView>
                     )
                 }

--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -26,11 +26,6 @@ const FilesTabScreen = () => {
     const [allFiles, setAllFiles] = useState<FileCardType[]>( [] as FileCardType[]);
     const [latestFiles, setLatestFiles] = useState<FileCardType[]>( [] as FileCardType[]);
 
-    const onRefresh = useCallback(() => {
-        fetchFolderContent();
-        fetchLatestFiles();
-    }, []);
-
     const fetchFolderContent = async () => {
         const content = await getFolderContent("/remote.php/dav/files/testuser/");
         if (content) {
@@ -46,12 +41,21 @@ const FilesTabScreen = () => {
         }
     };
 
-    useEffect(() => {
+    const fetchAllData = () => {
         fetchFolderContent();
         fetchLatestFiles();
+    }
+
+    const onRefresh = useCallback(() => { fetchAllData() }, []);
+
+
+    useEffect(() => {
+        fetchAllData();
     }, []);
 
     const toggleFileView = () => {
+        fetchLatestFiles();
+        fetchFolderContent();
         setFileView(fileView === FileView.Courses ? FileView.Activity : FileView.Courses);
     };
 

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -51,14 +51,10 @@ const FileCard = (props: FileCardProps) => {
     const handleDownloadFile = () => {
         downloadFile(props.fileURL)
             .then(status => {
-                if (status) {
-                    if (Platform.OS === "android") {
-                        ToastAndroid.show("File downloaded!", ToastAndroid.SHORT);
-                    } else {
-                        Alert.alert("File downloaded!");
-                    }
+                if (Platform.OS === "android") {
+                    ToastAndroid.show("File downloaded!", ToastAndroid.SHORT);
                 } else {
-                    Alert.alert("Download Failed", "An error occurred while downloading the file.");
+                    Alert.alert("File downloaded!");
                 }
             })
             .catch(error => {

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -29,14 +29,7 @@ const FileCard = (props: FileCardProps) => {
             setFileType("pdf");
         }
         else if (props.fileType.split("/")[0] === "image") {
-            const fetchImage = async () => {
-                try {
-                    const base64Image = await fetchFile(props.fileURL);
-                    setPreviewImage({ uri: base64Image });
-                } catch (error) {
-                    console.error(error);
-                }
-            };
+            
             fetchImage();
             setFileType("image");
         }
@@ -45,34 +38,51 @@ const FileCard = (props: FileCardProps) => {
         }
     }, [props.fileType, props.fileURL]);
 
-    const handleDownloadFile = async() => {
-        const status = await downloadFile(props.fileURL);
-        if (status) {
-            if (Platform.OS === "android") {
-                ToastAndroid.show("File downloaded!", ToastAndroid.SHORT)
-            } else {
-                Alert.alert("File downloaded!");
-            }
-        }
-        else {
-            Alert.alert("Download Failed", "An error occurred while downloading the file.");
-        }
-    }
+    const fetchImage = () => {
+        fetchFile(props.fileURL)
+            .then(base64Image => {
+                setPreviewImage({ uri: base64Image });
+            })
+            .catch(error => {
+                console.error(error);
+            });
+    };
+    
+    const handleDownloadFile = () => {
+        downloadFile(props.fileURL)
+            .then(status => {
+                if (status) {
+                    if (Platform.OS === "android") {
+                        ToastAndroid.show("File downloaded!", ToastAndroid.SHORT);
+                    } else {
+                        Alert.alert("File downloaded!");
+                    }
+                } else {
+                    Alert.alert("Download Failed", "An error occurred while downloading the file.");
+                }
+            })
+            .catch(error => {
+                console.error('Download File Error:', error);
+                Alert.alert("Download Failed", "An unexpected error occurred while downloading the file.");
+            });
+    };
 
-    const handleDeleteFile = async() => {
-        const status = await deleteItem(props.fileURL);
-        if (status) {
-            props.cardRemovalHandler(props.fileURL);
-            if (Platform.OS === "android") {
-                ToastAndroid.show("File deleted!", ToastAndroid.SHORT)
-            } else {
-                Alert.alert("File deleted!");
-            }
-        }
-        else {
-            Alert.alert("Deletion Failed!", `An error occurred while deleting the file.`);
-        }
-    }
+    
+    const handleDeleteFile = () => {
+        deleteItem(props.fileURL)
+            .then(result => {
+                props.cardRemovalHandler(props.fileURL);
+                if (Platform.OS === "android") {
+                    ToastAndroid.show("File deleted!", ToastAndroid.SHORT);
+                } else {
+                    Alert.alert("File deleted!");
+                }
+            })
+            .catch(error => {
+                Alert.alert("Deletion Failed!", `An error occurred while deleting the file.`);
+            });
+    };
+    
 
     return (
         <View style={styles.container}>

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -14,7 +14,7 @@ const noPreviewImage = require("../../assets/basic-file-icon.png");
 
 
 interface FileCardProps extends FileCardType {
-    cardRemovalHandler: (url: string) => void
+    cardRemovalHandler: () => void
 }
 
 
@@ -67,16 +67,16 @@ const FileCard = (props: FileCardProps) => {
     const handleDeleteFile = () => {
         deleteItem(props.fileURL)
             .then(result => {
-                props.cardRemovalHandler(props.fileURL);
                 if (Platform.OS === "android") {
                     ToastAndroid.show("File deleted!", ToastAndroid.SHORT);
                 } else {
                     Alert.alert("File deleted!");
                 }
+                props.cardRemovalHandler();
             })
             .catch(error => {
                 Alert.alert("Deletion Failed!", `An error occurred while deleting the file.`);
-            });
+            })
     };
     
 

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -15,7 +15,7 @@ const noPreviewImage = require("../../assets/basic-file-icon.png");
 
 
 interface FileCardProps extends FileCardType {
-    cardRemovalHandler?: (url: string) => void
+    cardRemovalHandler: (url: string) => void
 }
 
 
@@ -59,7 +59,7 @@ const FileCard = (props: FileCardProps) => {
     const handleDeleteFile = async() => {
         const status = await deleteItem(props.fileURL);
         if (status) {
-            props.cardRemovalHandler?(props.fileURL) : undefined;
+            props.cardRemovalHandler(props.fileURL);
             ToastAndroid.show("File deleted!", ToastAndroid.SHORT);
         }
         else {

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -1,6 +1,5 @@
-import { StyleSheet, View, Text, Image, TouchableOpacity, ToastAndroid } from "react-native";
+import { StyleSheet, View, Text, Image, TouchableOpacity, ToastAndroid, Platform, Alert, Pressable } from "react-native";
 import Popover from "react-native-popover-view";
-import { Alert } from "react-native";
 import { Entypo } from "@expo/vector-icons";
 import Feather from "@expo/vector-icons/Feather";
 import { AntDesign } from "@expo/vector-icons";
@@ -49,7 +48,11 @@ const FileCard = (props: FileCardProps) => {
     const handleDownloadFile = async() => {
         const status = await downloadFile(props.fileURL);
         if (status) {
-            ToastAndroid.show("File downloaded!", ToastAndroid.SHORT);
+            if (Platform.OS === "android") {
+                ToastAndroid.show("File downloaded!", ToastAndroid.SHORT)
+            } else {
+                Alert.alert("File downloaded!");
+            }
         }
         else {
             Alert.alert("Download Failed", "An error occurred while downloading the file.");
@@ -60,7 +63,11 @@ const FileCard = (props: FileCardProps) => {
         const status = await deleteItem(props.fileURL);
         if (status) {
             props.cardRemovalHandler(props.fileURL);
-            ToastAndroid.show("File deleted!", ToastAndroid.SHORT);
+            if (Platform.OS === "android") {
+                ToastAndroid.show("File deleted!", ToastAndroid.SHORT)
+            } else {
+                Alert.alert("File deleted!");
+            }
         }
         else {
             Alert.alert("Deletion Failed!", `An error occurred while deleting the file.`);
@@ -80,8 +87,11 @@ const FileCard = (props: FileCardProps) => {
             </View>
 
             <Popover
+                animationConfig={{
+                    duration: 300
+                }}
                 from={(
-                    <TouchableOpacity>
+                    <TouchableOpacity style={styles.openSettingsButton}>
                         <Entypo name="dots-three-vertical" size={20} color={Colors.primary} />
                     </TouchableOpacity>
                 )}>
@@ -134,12 +144,17 @@ const styles = StyleSheet.create({
     },
     tagPlaceHolder: {
         flex: 1,
-        backgroundColor: "#cfcfcf",
+        backgroundColor: "#dfdfdf",
         height: 20,
     },
     fileName: {
+        flex: 1,
         fontSize: 15,
         color: Colors.primary,
+    },
+    openSettingsButton: {
+        flex: 1,
+        alignItems: "center",
     },
     settingModal: {
         width: 250,

--- a/app/components/FileList.tsx
+++ b/app/components/FileList.tsx
@@ -19,8 +19,8 @@ const FileList = (props: FileListType) => {
         setFolders(props.folders);
     }, [props.files, props.folders]);
 
-    const cardRemovalHandler = (url: string) => {
-        setFiles(prevFiles => prevFiles.filter(file => file.fileURL !== url));
+    const cardRemovalHandler = () => {
+        props.refreshFunction ? props.refreshFunction() : null
     }
 
     return (

--- a/app/components/FolderContentScreen.tsx
+++ b/app/components/FolderContentScreen.tsx
@@ -52,7 +52,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                 <RefreshControl refreshing={false} onRefresh={onRefresh} />
         }
             >
-            <FileList folders={allFolders} files={allFiles}/>
+            <FileList folders={allFolders} files={allFiles} refreshFunction={fetchFolderContent}/>
         </ScrollView>     
     );
 };

--- a/app/types/FileTypes.ts
+++ b/app/types/FileTypes.ts
@@ -14,4 +14,5 @@ export interface FileCardType {
 export interface FileListType {
     folders: FolderCardType[],
     files: FileCardType[],
+    refreshFunction?: () => void
 }

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -170,14 +170,14 @@ export const downloadFile = (fileURL: string): Promise<boolean | void> => {
                                     });
                                 })
                                 .catch(error => {
-                                    return false;
+                                    return error;
                                 });
                         } else {
                             return Sharing.shareAsync(base64Data, { mimeType: "application/octet-stream", dialogTitle: "Share the file" });
                         }
                     })
                     .catch(error => {
-                        return false;
+                        return error;
                     });
             } else {
                 const fileUri = `${FileSystem.cacheDirectory}${fileName}`;
@@ -188,14 +188,14 @@ export const downloadFile = (fileURL: string): Promise<boolean | void> => {
                     return Sharing.shareAsync(fileUri, { mimeType: "application/octet-stream", dialogTitle: "Share the file" });
                 })
                 .catch(error => {
-                    return false;
+                    return error;
                 });
             }
         })
-        .then((result) => true)
+        .then((result) => result)
         .catch(error => {
             console.error('Download File Error:', error);
-            return false;
+            return error;
         });
 };
 

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -4,7 +4,6 @@ import * as FileSystem from "expo-file-system";
 import { Alert, Platform } from "react-native";
 import Constants from "expo-constants";
 import * as Sharing from "expo-sharing";
-import axios from "axios";
 var parseString = require("react-native-xml2js").parseString;
 
 
@@ -119,6 +118,7 @@ export const searchLatestFiles = async(): Promise<FileCardType[] | void> => {
 export const fetchFile = (fileURL: string): Promise<string | void> => {
     const requestHeaders = new Headers();
     requestHeaders.append("Authorization", `Basic ${process.env.EXPO_PUBLIC_TOKEN}`);
+    //requestHeaders.append("If-none-match", "browtf");
 
     const requestOptions: RequestInit = {
         method: "GET",
@@ -200,18 +200,29 @@ export const downloadFile = (fileURL: string): Promise<void> => {
 };
 
 export const deleteItem = async (itemURL: string): Promise<void> => {
-    const requestConfig = {
-        headers: {
-            Authorization: `Basic ${process.env.EXPO_PUBLIC_TOKEN}`,
-        }
+    const requestHeaders = new Headers();
+    requestHeaders.append("Authorization", `Basic ${process.env.EXPO_PUBLIC_TOKEN}`);
+    requestHeaders.append("If-none-match", "areyoukiddingmeapple");
+
+    const requestOptions: RequestInit = {
+        method: "DELETE",
+        headers: requestHeaders,
+        redirect: "follow"
     };
 
     try {
-        const response = await axios.delete(machineURL + itemURL, requestConfig);
+        const response = await fetch(machineURL + itemURL, requestOptions);
+
+        if (!response.ok) {
+            const errorMessage = await response.text();
+            console.debug(errorMessage);
+            throw new Error(errorMessage);
+        }
     } catch (error) {
         throw error;
     }
 };
+
 
 export const createFolder = async (folderURL: string): Promise<boolean | void> => {
     const requestHeaders = new Headers();

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -4,6 +4,7 @@ import * as FileSystem from "expo-file-system";
 import { Alert, Platform } from "react-native";
 import Constants from "expo-constants";
 import * as Sharing from "expo-sharing";
+import axios from "axios";
 var parseString = require("react-native-xml2js").parseString;
 
 
@@ -141,19 +142,19 @@ export const fetchFile = (fileURL: string): Promise<string | void> => {
             });
         })
         .catch(error => {
-            console.error(error);
+            throw error;
         });
 };
 
 
-export const downloadFile = (fileURL: string): Promise<boolean | void> => {
+export const downloadFile = (fileURL: string): Promise<void> => {
     return fetchFile(fileURL)
         .then(base64Data => {
             if (!base64Data) {
                 throw new Error("Failed to fetch file content");
             }
 
-            const fileName = fileURL.split("/").pop();
+            const fileName = fileURL.split("/").pop()?.split("%20").join("-");
             if (!fileName) {
                 throw new Error("Invalid file URL");
             }
@@ -192,30 +193,25 @@ export const downloadFile = (fileURL: string): Promise<boolean | void> => {
                 });
             }
         })
-        .then((result) => result)
         .catch(error => {
             console.error('Download File Error:', error);
             return error;
         });
 };
 
-
 export const deleteItem = async (itemURL: string): Promise<void> => {
-    const requestHeaders = new Headers();
-    requestHeaders.append("Authorization", `Basic ${process.env.EXPO_PUBLIC_TOKEN}`);
-
-    const requestOptions = {
-        method: "DELETE",
-        headers: requestHeaders,
-        redirect: "follow"
+    const requestConfig = {
+        headers: {
+            Authorization: `Basic ${process.env.EXPO_PUBLIC_TOKEN}`,
+        }
     };
 
-    return fetch(machineURL+itemURL, requestOptions as RequestInit)
-        .then((response) => {})
-        .catch((error) => {
-            throw error;
-        });
-}
+    try {
+        const response = await axios.delete(machineURL + itemURL, requestConfig);
+    } catch (error) {
+        throw error;
+    }
+};
 
 export const createFolder = async (folderURL: string): Promise<boolean | void> => {
     const requestHeaders = new Headers();

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -192,7 +192,7 @@ export const downloadFile = (fileURL: string): Promise<boolean | void> => {
                 });
             }
         })
-        .then((result) => result)
+        .then((result) => true)
         .catch(error => {
             console.error('Download File Error:', error);
             return false;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "axios": "^1.7.2",
     "expo": "^51.0.11",
     "expo-constants": "~16.0.2",
     "expo-linking": "~6.3.1",
@@ -18,6 +19,7 @@
     "react": "18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "0.74.2",
+    "react-native-axios": "^0.17.1",
     "react-native-popover-view": "^5.1.8",
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",


### PR DESCRIPTION
Closes #28 

I added the functionality for refreshing the file data on the phone to be in sync with nextcloud. I also made it so that deleting a file in, eg the courses tab will also remove the file in the activity tab without refreshing. One thing I noticed is that when deleting a file you get a warning popup saying "Possibly unhandled promise rejection" but I just couldn't find the cause. it doesnt break anything but it still bugs me... Anyways, this led me to also slightly rewrite the request functions for fetching downloading and deleting files becasue it makes error handling simpler. I hope this doesnt create a conflict with any of you. Cheers