### PR TITLE
Detect personal-space folder and move to very top, decode url encoded …

### DIFF
--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -26,15 +26,15 @@ interface TimeGroupedFiles {
 
 const FilesTabScreen = () => {
     const [fileView, setFileView] = useState<FileView>(FileView.Activity);
-    const [timeGroupedFiles, setTimeGroupedFiles] = useState<TimeGroupedFiles>();
     const [allFolders, setAllFolders] = useState<FolderCardType[]>( [] as FolderCardType[]);
     const [allFiles, setAllFiles] = useState<FileCardType[]>( [] as FileCardType[]);
     const [latestFiles, setLatestFiles] = useState<FileCardType[]>( [] as FileCardType[]);
 
+    const FILE_URL = `/remote.php/dav/files/${process.env.EXPO_PUBLIC_USER}/`;
 
     useEffect(() => {
         const fetchFolderContent = async () => {
-            const content = await getFolderContent("/remote.php/dav/files/testuser/");
+            const content = await getFolderContent(FILE_URL);
             if (content) {
                 setAllFiles(content.files);
                 setAllFolders(content.folders);

--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -10,7 +10,7 @@ import { FileCardType, FolderCardType } from "../types/FileTypes";
 import FolderContentScreen, { RootStackParamList }  from "../components/FolderContentScreen";
 import Colors from "../utils/Colors";
 import { getFolderContent, searchLatestFiles} from "../utils/ServerRequests";
-import { getTimeFrame, LastModified } from "../utils/utils";
+import { getTimeFrame, LastModified, PERSONAL_SPACE_FOLDER_NAME } from "../utils/utils";
 
 
 enum FileView {
@@ -28,14 +28,29 @@ const FilesTabScreen = () => {
 
     const FILE_URL = `/remote.php/dav/files/${process.env.EXPO_PUBLIC_USER}/`;
 
+    const personalFolderToTop = (folders: FolderCardType[]) => {
+        const index = folders.findIndex(folder => decodeURIComponent(folder.folderName) === PERSONAL_SPACE_FOLDER_NAME);
+
+        if (index !== -1) {
+            const [personalSpaceFolder] = folders.splice(index, 1);
+            folders.unshift(personalSpaceFolder);
+        }
+
+        return folders;
+    }
+
+    // Fetch all root level files and folders
     const fetchFolderContent = async () => {
         const content = await getFolderContent(FILE_URL);
         if (content) {
             setAllFiles(content.files);
-            setAllFolders(content.folders);
+
+            let folders = personalFolderToTop(content.folders);
+            setAllFolders(folders);
         }
     };
     
+    // Fetch latest filles
     const fetchLatestFiles = async () => {
         const results = await searchLatestFiles();
         if (results) {
@@ -43,13 +58,14 @@ const FilesTabScreen = () => {
         }
     };
 
+    // Fetch latest files and all root level files and folders
     const fetchAllData = () => {
         fetchFolderContent();
         fetchLatestFiles();
     }
 
+    // Refetch data on refresh
     const onRefresh = useCallback(() => { fetchAllData() }, []);
-
 
     useEffect(() => {
         fetchAllData();

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -75,7 +75,7 @@ const FileCard = (props: FileCardProps) => {
                 resizeMode="contain"
             />
             <View style={styles.fileInfos}>
-                <Text style={styles.fileName}>{props.fileName.replace("%", " ")}</Text>
+                <Text style={styles.fileName}>{decodeURIComponent(props.fileName)}</Text>
                 <View style={styles.tagPlaceHolder} />
             </View>
 

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -162,7 +162,6 @@ const styles = StyleSheet.create({
     },
     settingModal: {
         width: 250,
-        height: 150,
         display: "flex",
         flexDirection: "column",
         gap: 10,
@@ -171,6 +170,7 @@ const styles = StyleSheet.create({
     settingButton: {
         flex: 1,
         borderRadius: 3,
+        height: 75,
         backgroundColor: Colors.surface,
         display: "flex",
         flexDirection: "row",

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -108,7 +108,7 @@ const FileCard = (props: FileCardProps) => {
                     </TouchableOpacity>
                     <TouchableOpacity style={styles.settingButton} onPress={() => handleDeleteFile()}>
                         <AntDesign name="delete" size={25} color={Colors.primary} />
-                        <Text style={styles.settingText}>DELETE</Text>
+                        <Text style={styles.settingText}>LÖSCHEN</Text>
                     </TouchableOpacity>
                 </View>
             </Popover>

--- a/app/components/FileList.tsx
+++ b/app/components/FileList.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, View } from "react-native";
 import { FileCardType, FolderCardType, FileListType } from "../types/FileTypes";
 import FileCard from "./FileCard";
 import FolderCard from "./FolderCard";
-
+import { PERSONAL_SPACE_FOLDER_NAME } from "../utils/utils";
 
 
 
@@ -13,8 +13,6 @@ const FileList = (props: FileListType) => {
 
     const [files, setFiles] = useState<FileCardType[]>([]);
     const [folders, setFolders] = useState<FolderCardType[]>([]);
-
-    const PERSONAL_SPACE_FOLDER_NAME = "Persönliche Ablage";
 
     // Moves the "personal space" folder to the very top if it exists
     const personalFolderToTop = (folders: FolderCardType[]) => {

--- a/app/components/FileList.tsx
+++ b/app/components/FileList.tsx
@@ -4,8 +4,6 @@ import { StyleSheet, View } from "react-native";
 import { FileCardType, FolderCardType, FileListType } from "../types/FileTypes";
 import FileCard from "./FileCard";
 import FolderCard from "./FolderCard";
-import { PERSONAL_SPACE_FOLDER_NAME } from "../utils/utils";
-
 
 
 const FileList = (props: FileListType) => {
@@ -14,22 +12,9 @@ const FileList = (props: FileListType) => {
     const [files, setFiles] = useState<FileCardType[]>([]);
     const [folders, setFolders] = useState<FolderCardType[]>([]);
 
-    // Moves the "personal space" folder to the very top if it exists
-    const personalFolderToTop = (folders: FolderCardType[]) => {
-        const index = folders.findIndex(folder => decodeURIComponent(folder.folderName) === PERSONAL_SPACE_FOLDER_NAME);
-
-        if (index !== -1) {
-            const [personalSpaceFolder] = folders.splice(index, 1);
-            folders.unshift(personalSpaceFolder);
-        }
-
-        return folders;
-    }
-
     useEffect(() => {
         setFiles(props.files);
-        const rearrangedFolders = personalFolderToTop(props.folders);
-        setFolders(rearrangedFolders);
+        setFolders(props.folders);
         
     }, [props.files, props.folders]);
 
@@ -45,6 +30,7 @@ const FileList = (props: FileListType) => {
                     folderName={folderData.folderName}
                     folderURL={folderData.folderURL}
                     navigation={navigation}
+                    cardRemovalHandler={cardRemovalHandler}
                 />
             ))}
             {files.map((fileData: FileCardType) => (

--- a/app/components/FileList.tsx
+++ b/app/components/FileList.tsx
@@ -14,9 +14,25 @@ const FileList = (props: FileListType) => {
     const [files, setFiles] = useState<FileCardType[]>([]);
     const [folders, setFolders] = useState<FolderCardType[]>([]);
 
+    const PERSONAL_SPACE_FOLDER_NAME = "Pesönliche Ablage";
+
+    // Moves the "personal space" folder to the very top if it exists
+    const personalFolderToTop = (folders: FolderCardType[]) => {
+        const index = folders.findIndex(folder => decodeURIComponent(folder.folderName) === PERSONAL_SPACE_FOLDER_NAME);
+
+        if (index !== -1) {
+            const [personalSpaceFolder] = folders.splice(index, 1);
+            folders.unshift(personalSpaceFolder);
+        }
+
+        return folders;
+    }
+
     useEffect(() => {
         setFiles(props.files);
-        setFolders(props.folders);
+        const rearangedFolders = personalFolderToTop(props.folders);
+        setFolders(rearangedFolders);
+        
     }, [props.files, props.folders]);
 
     const cardRemovalHandler = (url: string) => {

--- a/app/components/FolderCard.tsx
+++ b/app/components/FolderCard.tsx
@@ -24,9 +24,12 @@ const FolderCard = (props: FolderCardProps) => {
     const [deletable, setDeleteable] = useState<boolean>(false);
 
     useEffect(() => {
+        // Folders are deletable if they are subfolders of the persona-space folder
+        const peronalSpacepath = `/files/${process.env.EXPO_PUBLIC_USER}/${PERSONAL_SPACE_FOLDER_NAME}/`;
+
         setDeleteable(
-            decodeURI(props.folderURL)
-            .endsWith(`/files/${process.env.EXPO_PUBLIC_USER}/${PERSONAL_SPACE_FOLDER_NAME}/${decodeURI(props.folderName)}/`)
+            decodeURI(props.folderURL).includes(peronalSpacepath) &&
+            !decodeURI(props.folderURL).endsWith(peronalSpacepath)
         );
     }, []);
 

--- a/app/components/FolderCard.tsx
+++ b/app/components/FolderCard.tsx
@@ -22,7 +22,7 @@ const FolderCard = (props: FolderCardProps) => {
             onPress={() => { handleFolderPress() }}
         >
             <Image style={styles.folderIcon} source={pdfPreviewImage} resizeMode="contain" />
-            <Text style={styles.folderName}>{props.folderName}</Text>
+            <Text style={styles.folderName}>{decodeURIComponent(props.folderName)}</Text>
         </TouchableOpacity>
     );
 };
@@ -45,7 +45,7 @@ const styles = StyleSheet.create({
     },
     folderIcon: {
         flex: 1,
-        height: "50%",
+        height: "40%",
         borderRadius: 3,
     },
     folderName: {

--- a/app/components/FolderCard.tsx
+++ b/app/components/FolderCard.tsx
@@ -77,7 +77,7 @@ const FolderCard = (props: FolderCardProps) => {
                     <View style={styles.settingModal}>
                         <TouchableOpacity style={styles.settingButton} onPress={() => handleDeleteFolder()}>
                             <AntDesign name="delete" size={25} color={Colors.primary} />
-                            <Text style={styles.settingText}>DELETE</Text>
+                            <Text style={styles.settingText}>LÖSCHEN</Text>
                         </TouchableOpacity>
                     </View>
                 </Popover>

--- a/app/components/FolderCard.tsx
+++ b/app/components/FolderCard.tsx
@@ -1,28 +1,90 @@
-import { StyleSheet, Text, Image, TouchableOpacity } from "react-native";
-import React from "react";
+import { StyleSheet, Text, Image, TouchableOpacity, View, Platform, ToastAndroid, Alert } from "react-native";
+import React, { useEffect, useState } from "react";
 import Colors from "../utils/Colors";
 import { FolderCardType } from "../types/FileTypes";
+import { PERSONAL_SPACE_FOLDER_NAME } from "../utils/utils";
+
+import Popover from "react-native-popover-view";
+import { Entypo } from "@expo/vector-icons";
+import Feather from "@expo/vector-icons/Feather";
+import { AntDesign } from "@expo/vector-icons";
+import { deleteItem } from "../utils/ServerRequests";
 
 
 const pdfPreviewImage = require("../../assets/folder-icon.png");
 
 interface FolderCardProps extends FolderCardType {
-    navigation?: any
+    navigation?: any,
+    cardRemovalHandler: () => void
 }
 
-
 const FolderCard = (props: FolderCardProps) => {
+
+    const [settingsPopupVisible, setSettingsPopupVisible] = useState<boolean>(false);
+    const [deletable, setDeleteable] = useState<boolean>(false);
+
+    useEffect(() => {
+        setDeleteable(
+            decodeURI(props.folderURL)
+            .endsWith(`/files/${process.env.EXPO_PUBLIC_USER}/${PERSONAL_SPACE_FOLDER_NAME}/${decodeURI(props.folderName)}/`)
+        );
+    }, []);
+
     const handleFolderPress = async() => {
         props.navigation.push("FolderContentScreen", { folderURL: props.folderURL, folderName: props.folderName });
     }
+
+    const handleDeleteFolder = () => {
+        deleteItem(props.folderURL)
+            .then(_ => {
+                setSettingsPopupVisible(false);
+                if (Platform.OS === "android") {
+                    ToastAndroid.show("Folder deleted!", ToastAndroid.SHORT);
+                } else {
+                    Alert.alert("Folder deleted!");
+                }
+                props.cardRemovalHandler();
+            })
+            .catch(error => {
+                Alert.alert("Deletion Failed!", `An error occurred while deleting the file.`);
+            })
+    };
 
     return (
         <TouchableOpacity
             style={styles.container}
             onPress={() => { handleFolderPress() }}
         >
-            <Image style={styles.folderIcon} source={pdfPreviewImage} resizeMode="contain" />
+            <Image
+                style={styles.folderIcon}
+                source={pdfPreviewImage} 
+                resizeMode="contain"
+            />
             <Text style={styles.folderName}>{decodeURIComponent(props.folderName)}</Text>
+
+            {deletable ?
+                <Popover
+                    isVisible={settingsPopupVisible}
+                    onRequestClose={() => setSettingsPopupVisible(false)}
+                    animationConfig={{
+                        duration: 300
+                    }}
+                    from={(
+                        <TouchableOpacity style={styles.openSettingsButton} onPress={() => setSettingsPopupVisible(true)}>
+                            <Entypo name="dots-three-vertical" size={20} color={Colors.primary} />
+                        </TouchableOpacity>
+                    )}>
+                    <View style={styles.settingModal}>
+                        <TouchableOpacity style={styles.settingButton} onPress={() => handleDeleteFolder()}>
+                            <AntDesign name="delete" size={25} color={Colors.primary} />
+                            <Text style={styles.settingText}>DELETE</Text>
+                        </TouchableOpacity>
+                    </View>
+                </Popover>
+            : 
+                <View style={{flex: 1}} />
+            }
+
         </TouchableOpacity>
     );
 };
@@ -39,20 +101,46 @@ const styles = StyleSheet.create({
         borderColor: Colors.surfaceOutline,
         display: "flex",
         flexDirection: "row",
-        justifyContent: "flex-start",
         padding: 5,
-        gap: 20,
+        paddingLeft: 10,
+        gap: 10,
     },
     folderIcon: {
         flex: 1,
-        height: "40%",
-        borderRadius: 3,
+        height: "45%",
     },
     folderName: {
-        flex: 7,
+        flex: 6,
         fontSize: 15,
         color: Colors.primary,
     },
+    openSettingsButton: {
+        flex: 1,
+        alignItems: "center",
+    },
+    settingModal: {
+        width: 250,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        padding: 10
+    },
+    settingButton: {
+        flex: 1,
+        borderRadius: 3,
+        height: 75,
+        backgroundColor: Colors.surface,
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10
+    },
+    settingText: {
+        fontWeight: "bold",
+        color: Colors.primary,
+        fontSize: 17
+    }
 });
 
 export default FolderCard;

--- a/app/components/FolderContentScreen.tsx
+++ b/app/components/FolderContentScreen.tsx
@@ -25,6 +25,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
     const [allFolders, setAllFolders] = useState<FolderCardType[]>([] as FolderCardType[]);
     const [allFiles, setAllFiles] = useState<FileCardType[]>([] as FileCardType[]);
     const [settingsPopupVisible, setSettingsPopupVisible] = useState<boolean>(false);
+    const [invalidFolderName, setInvalidFolderName] = useState<boolean>(false);
 
     useLayoutEffect(() => {
         navigation.setOptions({
@@ -53,7 +54,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
         }
     };
 
-    const [inputText, setInputText] = useState('');
+    const [newFolderName, setNewFolderName] = useState('');
     const [modalVisible, setModalVisible] = useState(false);
 
     const uploadFileHandler = async () => {
@@ -88,7 +89,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
 
     const addFolderHandler = async () => {
         try {
-            await createFolder(`${props.route.params?.folderURL}/${inputText}`).then((status) => {
+            await createFolder(`${props.route.params?.folderURL}/${newFolderName}`).then((status) => {
                 if (status) {
                     if (Platform.OS === "android") {
                         ToastAndroid.show("File uploaded!", ToastAndroid.SHORT);
@@ -137,7 +138,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                     )}>
                         <View style={styles.settingModal}>
                             <TouchableOpacity style={styles.settingButton} onPress={() => uploadFileHandler()}>
-                                <AntDesign name="addfolder" size={25} color={Colors.primary} />
+                                <AntDesign name="addfile" size={25} color={Colors.primary} />
                                 <Text style={styles.settingText}>NEUE DATEI</Text>
                             </TouchableOpacity>
                             <TouchableOpacity style={styles.settingButton} onPress={() => {
@@ -148,7 +149,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                                 }, 1000)
                                 setSettingsPopupVisible(false);
                             }}>
-                                <AntDesign name="addfile" size={25} color={Colors.primary} />
+                                <AntDesign name="addfolder" size={25} color={Colors.primary} />
                                 <Text style={styles.settingText}>NEUER ORDNER</Text>
                             </TouchableOpacity>
                         </View>
@@ -179,17 +180,29 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                         <TextInput
                             style={styles.textInput}
                             placeholder="Wähle einen Ordner Namen..."
-                            value={inputText}
+                            value={newFolderName}
                             onChangeText={(text: string) => {
-                                setInputText(text);
+                                if (/[^a-zA-Z0-9-_ ]/.test(text)) {
+                                    setInvalidFolderName(true);
+                                }
+                                else {
+                                    setInvalidFolderName(false);
+                                }
+                                setNewFolderName(text);
                             }}
                         />
+                        {
+                            invalidFolderName ?
+                                <Text style={{color: "red", textAlign: "center"}}>Nur Buchstaben, Zahlen, "-", "_" und Leerzeichen sind erlaubt!</Text>
+                            : null
+                        }
                         <TouchableOpacity
-                            style={styles.addFolderButton}
+                            style={{ ...styles.addFolderButton, backgroundColor: invalidFolderName ? "#cacaca" : Colors.yellow }}
+                            disabled={invalidFolderName}
                             onPress={() => {
                                 setModalVisible(false);
                                 addFolderHandler();
-                                setInputText("");
+                                setNewFolderName("");
                             }}
                         >
                             <Feather name="plus" size={20} color="#fff" />
@@ -271,32 +284,32 @@ const styles = StyleSheet.create({
     },
     modalOverlay: {
         flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
     },
     modalContainer: {
         width: 300,
         padding: 20,
-        backgroundColor: 'white',
+        backgroundColor: "white",
         borderRadius: 10,
-        alignItems: 'center',
+        display: "flex",
+        gap: 10,
+        alignItems: "center",
     },
     modalTitle: {
         fontWeight: "bold",
         color: Colors.primary,
         fontSize: 20,
-        marginBottom: 20,
     },
     textInput: {
-        width: '100%',
+        width: "100%",
         padding: 10,
         borderColor: Colors.secondary,
         borderRadius: 3,
         borderWidth: 1,
-        marginBottom: 20,
     },
-    inputText: {
+    newFolderName: {
         marginTop: 20,
         color: Colors.primary,
         fontSize: 18,

--- a/app/components/FolderContentScreen.tsx
+++ b/app/components/FolderContentScreen.tsx
@@ -1,15 +1,15 @@
-import { StyleSheet, ScrollView, RefreshControl, TouchableOpacity, Text, View, Platform, ToastAndroid, Alert } from "react-native";
+import { StyleSheet, ScrollView, RefreshControl, TouchableOpacity, Text, View, Platform, ToastAndroid, Alert, TextInput, Modal } from "react-native";
 import FileList from "./FileList";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useNavigation } from "expo-router";
 import React, { useEffect, useState, useLayoutEffect, useCallback } from "react";
-import { getFolderContent, uploadFile } from "../utils/ServerRequests";
+import { getFolderContent, uploadFile, createFolder } from "../utils/ServerRequests";
 import { FolderCardType, FileCardType } from "../types/FileTypes";
 import Feather from "@expo/vector-icons/Feather";
+import { AntDesign } from "@expo/vector-icons";
 import Colors from "../utils/Colors";
-import { pickFileFromDevice } from "../utils/utils";
-import { PERSONAL_SPACE_FOLDER_NAME } from "../utils/utils";
-
+import { PERSONAL_SPACE_FOLDER_NAME, pickFileFromDevice } from "../utils/utils";
+import Popover from "react-native-popover-view";
 
 
 export type RootStackParamList = {
@@ -24,6 +24,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
     const [isPersonalFolder, setIsPersonalFolder] = useState<boolean>(false);
     const [allFolders, setAllFolders] = useState<FolderCardType[]>([] as FolderCardType[]);
     const [allFiles, setAllFiles] = useState<FileCardType[]>([] as FileCardType[]);
+    const [settingsPopupVisible, setSettingsPopupVisible] = useState<boolean>(false);
 
     useLayoutEffect(() => {
         navigation.setOptions({
@@ -35,7 +36,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
         fetchFolderContent();
         setIsPersonalFolder(
             decodeURI(props.route.params?.folderURL)
-            .endsWith(`/files/${process.env.EXPO_PUBLIC_USER}/${PERSONAL_SPACE_FOLDER_NAME}/`)
+            .includes(`/files/${process.env.EXPO_PUBLIC_USER}/${PERSONAL_SPACE_FOLDER_NAME}/`)
         );
     }, []);
 
@@ -51,7 +52,10 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
             setAllFolders(content.folders);
         }
     };
-    
+
+    const [inputText, setInputText] = useState('');
+    const [modalVisible, setModalVisible] = useState(false);
+
     const uploadFileHandler = async () => {
         try {
             pickFileFromDevice().then((uploadedFileData) => {
@@ -67,6 +71,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                         Alert.alert("File uploaded!");
                     }
                 }
+                setSettingsPopupVisible(false);
             }).then(async () => {
                 // Refresh after 2 seconds to see new file
                 setTimeout(() => {
@@ -77,7 +82,32 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
             });   
         }
         catch {
-            Alert.alert("File upload failed!");
+            Alert.alert("Failed to upload file!");
+        }
+    }
+
+    const addFolderHandler = async () => {
+        try {
+            await createFolder(`${props.route.params?.folderURL}/${inputText}`).then((status) => {
+                if (status) {
+                    if (Platform.OS === "android") {
+                        ToastAndroid.show("File uploaded!", ToastAndroid.SHORT);
+                    }
+                    else {
+                        Alert.alert("File uploaded!");
+                    }
+                }
+            }).then(async () => {
+                // Refresh after 2 seconds to see new file
+                setTimeout(() => {
+                    fetchFolderContent();
+                }, 2500)
+            }).catch((error) => {
+                throw error;
+            });  
+        }
+        catch {
+            Alert.alert("Failed to add folder!");
         }
     }
 
@@ -91,17 +121,83 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                 >
                 <FileList folders={allFolders} files={allFiles} refreshFunction={onRefresh}/>
             </ScrollView>
+
             {
                 isPersonalFolder ?
-                    <View style={styles.uploadSection}>
-                        <TouchableOpacity style={styles.uploadButton} onPress={uploadFileHandler}>
-                            <Feather name="upload" size={25} color="#fff" />
-                            <Text style={styles.uploadText}>UPLOAD</Text>
-                        </TouchableOpacity>
-                    </View>
+                    <Popover
+                        isVisible={settingsPopupVisible}
+                        onRequestClose={() => setSettingsPopupVisible(false)}
+                        animationConfig={{
+                            duration: 300
+                        }}
+                        from={(
+                            <TouchableOpacity style={styles.uploadButton} onPress={() => setSettingsPopupVisible(true)}>
+                                <Feather name="plus" size={40} color="#fff" />
+                            </TouchableOpacity>
+                    )}>
+                        <View style={styles.settingModal}>
+                            <TouchableOpacity style={styles.settingButton} onPress={() => uploadFileHandler()}>
+                                <AntDesign name="addfolder" size={25} color={Colors.primary} />
+                                <Text style={styles.settingText}>NEUE DATEI</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity style={styles.settingButton} onPress={() => {
+                                setTimeout(() => {
+                                    // For some reason iOS needs a second before it registers the modal.
+                                    // If we don't wait the modal is invisible.
+                                    setModalVisible(true)
+                                }, 1000)
+                                setSettingsPopupVisible(false);
+                            }}>
+                                <AntDesign name="addfile" size={25} color={Colors.primary} />
+                                <Text style={styles.settingText}>NEUER ORDNER</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </Popover>
                 :
                     null
             }
+
+            <Modal
+                animationType="slide"
+                transparent={true}
+                visible={modalVisible}
+                onRequestClose={() => setModalVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.modalContainer}>
+
+                        <TouchableOpacity
+                            style={styles.closeModal}
+                            onPress={() => {
+                                setModalVisible(false);
+                            }}
+                        >
+                            <Feather name="x" size={20} color="black" />
+                        </TouchableOpacity>
+
+                        <Text style={styles.modalTitle}>Ordner Name</Text>
+                        <TextInput
+                            style={styles.textInput}
+                            placeholder="Wähle einen Ordner Namen..."
+                            value={inputText}
+                            onChangeText={(text: string) => {
+                                setInputText(text);
+                            }}
+                        />
+                        <TouchableOpacity
+                            style={styles.addFolderButton}
+                            onPress={() => {
+                                setModalVisible(false);
+                                addFolderHandler();
+                                setInputText("");
+                            }}
+                        >
+                            <Feather name="plus" size={20} color="#fff" />
+                            <Text style={styles.addFolderSubmitText}>HINZUFÜGEN</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </Modal>
             
         </View>
     );
@@ -127,9 +223,12 @@ const styles = StyleSheet.create({
         paddingTop: 5
     },
     uploadButton: {
-        height: 45,
-        width: 150,
-        borderRadius: 5,
+        position: "absolute",
+        right: 30,
+        bottom: 30,
+        height: 60,
+        width: 60,
+        borderRadius: 60,
         backgroundColor: Colors.yellow,
         display: "flex",
         flexDirection: "row",
@@ -142,6 +241,85 @@ const styles = StyleSheet.create({
         fontWeight: "bold",
         textAlign: "center",
         fontSize: 17
+    },
+    openSettingsButton: {
+        flex: 1,
+        alignItems: "center",
+    },
+    settingModal: {
+        width: 250,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        padding: 10
+    },
+    settingButton: {
+        flex: 1,
+        borderRadius: 3,
+        height: 75,
+        backgroundColor: Colors.surface,
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10
+    },
+    settingText: {
+        fontWeight: "bold",
+        color: Colors.primary,
+        fontSize: 17
+    },
+    modalOverlay: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    modalContainer: {
+        width: 300,
+        padding: 20,
+        backgroundColor: 'white',
+        borderRadius: 10,
+        alignItems: 'center',
+    },
+    modalTitle: {
+        fontWeight: "bold",
+        color: Colors.primary,
+        fontSize: 20,
+        marginBottom: 20,
+    },
+    textInput: {
+        width: '100%',
+        padding: 10,
+        borderColor: Colors.secondary,
+        borderRadius: 3,
+        borderWidth: 1,
+        marginBottom: 20,
+    },
+    inputText: {
+        marginTop: 20,
+        color: Colors.primary,
+        fontSize: 18,
+    },
+    addFolderButton: {
+        width: "auto",
+        height: 30,
+        borderRadius: 3,
+        backgroundColor: Colors.yellow,
+        display: "flex",
+        flexDirection: "row",
+        gap: 3,
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 10
+    },
+    addFolderSubmitText: {
+        color: "#fff",
+        fontSize: 17,
+        fontWeight: "bold"
+    },
+    closeModal: {
+        width: "100%",
     }
 });
 

--- a/app/components/FolderContentScreen.tsx
+++ b/app/components/FolderContentScreen.tsx
@@ -182,7 +182,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                             placeholder="Wähle einen Ordner Namen..."
                             value={newFolderName}
                             onChangeText={(text: string) => {
-                                if (/[^a-zA-Z0-9-_ ]/.test(text)) {
+                                if (/[^-\w\s\p{L}]/u.test(text) || text.length > 128) {
                                     setInvalidFolderName(true);
                                 }
                                 else {
@@ -193,7 +193,7 @@ const FolderContentScreen = (props: NativeStackScreenProps<RootStackParamList, "
                         />
                         {
                             invalidFolderName ?
-                                <Text style={{color: "red", textAlign: "center"}}>Nur Buchstaben, Zahlen, "-", "_" und Leerzeichen sind erlaubt!</Text>
+                                <Text style={{color: "red", textAlign: "center"}}>Nur Buchstaben, Zahlen, "-", "_" und Leerzeichen sind erlaubt (max. 128)!</Text>
                             : null
                         }
                         <TouchableOpacity

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -214,7 +214,6 @@ export const deleteItem = async (itemURL: string): Promise<void> => {
 
         if (!response.ok) {
             const errorMessage = await response.text();
-            console.debug(errorMessage);
             throw new Error(errorMessage);
         }
     } catch (error) {

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -10,6 +10,9 @@ export enum LastModified {
 }
 
 
+export const PERSONAL_SPACE_FOLDER_NAME = "Persönliche Ablage";
+
+
 export function getTimeFrame(dateTimeString: string): LastModified {
     try {
         const dateTime = new Date(dateTimeString);


### PR DESCRIPTION
Closes #29 
In order to display the personal folder for tutors we need to fetch the root folders as usual and the when we detect a folder called "Persönliche Ablage" it should be moved to the very top of the folders list so it's shown at the first folder. To test this please create a folder called ``Persönliche Ablage`` in NextCloud.

Now I also decode the file and folder names. Previously they were url-encoded. for example all spaces where "%20", eg. ``Nextcloud%20Logo.jpg``, now it will be displayed as ``Nextcloud 20Logo.jpg``, this also makes Umlaute (äöü) etc work.

### Edit:
I forgot to add the functionality that users can also upload files into their personal space. So now there is an upload button with which you can upload files in there. The question remains if I also should add a "create folder" button, in order to create a sub folder. Let me now. We can also do this in the future if we need to.