### PR TITLE
Display tags on filecards, add option to fitler files by tags

### DIFF
--- a/app/(tabs)/files.tsx
+++ b/app/(tabs)/files.tsx
@@ -189,8 +189,8 @@ const FilesTabScreen = () => {
                         <ScrollView style={styles.tagSelectModal}>
                             <Text style={styles.tagSelectInstruction}>Tag auswählen:</Text>
                             {
-                                allSystemTags.map((tag: FileTagType) => 
-                                    <TouchableOpacity style={styles.tagSelectButton} onPress={async () => {
+                                allSystemTags.map((tag: FileTagType, index: number) => 
+                                    <TouchableOpacity key={index} style={styles.tagSelectButton} onPress={async () => {
                                         const filesByTag = await getAllFilesBySystemTag(tag.tagID);
                                         if (!filesByTag || filesByTag.length === 0) {
                                             Alert.alert("Tag nicht gefunden!", `Es existieren keine Dateien mit dem Tag "${tag.tagName}".`);

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -6,11 +6,12 @@ import { AntDesign } from "@expo/vector-icons";
 import React, { useEffect, useState } from "react";
 import Colors from "../utils/Colors";
 import { fetchFile, downloadFile, deleteItem } from "../utils/ServerRequests";
-import { FileCardType } from "../types/FileTypes";
+import { FileCardType, FileTagType } from "../types/FileTypes";
 import * as FileSystem from 'expo-file-system';
 import * as IntentLauncher from "expo-intent-launcher";
 import WebView from "react-native-webview";
 import { hashString } from "../utils/utils";
+import TagBadge from "./TagBadge";
 
 const pdfPreviewImage = require("../../assets/pdf-icon.png");
 const noPreviewImage = require("../../assets/basic-file-icon.png");
@@ -26,6 +27,8 @@ const FileCard = (props: FileCardProps) => {
     const [isPreviewVisible, setIsPreviewVisible] = useState<boolean>(false);
     const [pdfBase64, setPdfBase64] = useState<string | null>(null);
     const [webViewUri, setWebViewUri] = useState('');
+
+    const FILE_BASE_URL = `/remote.php/dav/files/${process.env.EXPO_PUBLIC_USER}/`;
 
     useEffect(() => {
         if (props.fileType === "application/pdf") {
@@ -148,6 +151,13 @@ const FileCard = (props: FileCardProps) => {
         }
     };
 
+
+    const getFileFolderPath = (): string => {
+        let filePath = decodeURI(props.fileURL.replace(FILE_BASE_URL, "")).split("/");
+        filePath.pop();
+        return filePath.join("/");
+    }
+
     return (
         <TouchableOpacity style={styles.container} onPress={displayFile}>
             <Image
@@ -157,7 +167,21 @@ const FileCard = (props: FileCardProps) => {
             />
             <View style={styles.fileInfos}>
                 <Text style={styles.fileName}>{decodeURIComponent(props.fileName)}</Text>
-                <View style={styles.tagPlaceHolder} />
+                <View style={styles.tagContainer}>
+                    {
+                        props.fileTags && props.fileTags.length > 0 ?
+                            props.fileTags.map((tag: FileTagType, idx: number) => {
+                                return <TagBadge key={idx} name={tag.tagName} color={"green"} />
+                            })
+                        :
+                            <Text
+                                style={styles.filePath}
+                                numberOfLines={1}
+                            >
+                                {getFileFolderPath()}
+                            </Text>
+                    }
+                </View>
             </View>
 
             <Popover
@@ -257,12 +281,17 @@ const styles = StyleSheet.create({
     fileInfos: {
         flex: 6,
         display: "flex",
-        gap: 5,
     },
-    tagPlaceHolder: {
+    tagContainer: {
         flex: 1,
-        backgroundColor: "#dfdfdf",
-        height: 20,
+        display: "flex",
+        flexDirection: "row",
+        gap: 5,
+        overflow: "hidden",
+    },
+    filePath: {
+        color: Colors.secondary,
+        fontSize: 13,
     },
     fileName: {
         flex: 1,

--- a/app/components/FileCard.tsx
+++ b/app/components/FileCard.tsx
@@ -57,11 +57,15 @@ const FileCard = (props: FileCardProps) => {
 
     const fetchImage = async () => {
         const cacheDirectory = FileSystem.cacheDirectory + "images/";
-        const fileName = props.fileURL.split("/").pop();
+        let fileName = props.fileURL.split("/").pop();
         if (!fileName) {
             return;
         }
-        const fileUri = cacheDirectory + hashString(fileName);
+
+        if (Platform.OS === "android") [
+            fileName = hashString(fileName).toString()
+        ]
+        const fileUri = cacheDirectory + fileName;
 
         try {
             const dirInfo = await FileSystem.getInfoAsync(cacheDirectory);

--- a/app/components/FileList.tsx
+++ b/app/components/FileList.tsx
@@ -40,8 +40,9 @@ const FileList = (props: FileListType) => {
                     fileType={fileData.fileType}
                     fileURL={fileData.fileURL}
                     lastModified={fileData.lastModified}
-                    tags={fileData.tags}
+                    fileTags={fileData.fileTags}
                     cardRemovalHandler={cardRemovalHandler}
+                    fileID={fileData.fileID}
                 />
             ))}
         </View>

--- a/app/components/FileSearchBar.tsx
+++ b/app/components/FileSearchBar.tsx
@@ -51,6 +51,7 @@ const FileSearchBar: React.FunctionComponent<SearchBarProps> = (props: SearchBar
 
 const styles = StyleSheet.create({
     searchContainer: {
+        flex: 1,
         flexDirection: 'row',
         alignItems: 'center',
         padding: 0,

--- a/app/components/TagBadge.tsx
+++ b/app/components/TagBadge.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import Colors from '../utils/Colors';
+
+
+interface TagBadgeProps {
+    name: string;
+    color: string;
+}
+
+const TagBadge = (props: TagBadgeProps) => {
+    return (
+        <View style={styles.container}>
+            <Text style={styles.tagText}>{props.name}</Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        backgroundColor: Colors.secondary,
+        borderRadius: 100,
+        paddingHorizontal: 10,
+        opacity: 0.75,
+        height: 20
+    },
+    tagText: {
+        color: "rgba(0, 0, 0, 0.75)",
+        fontWeight: "bold",
+        fontSize: 13,
+    }
+});
+
+export default TagBadge;

--- a/app/utils/ExampleTags.ts
+++ b/app/utils/ExampleTags.ts
@@ -1,4 +1,0 @@
-//Json Object
-export const exampleTags = {
-    "Subjects": [ "Mathe", "Deutsch", "Englisch", "Latein", "Physik", "Biologie", "Geschichte", "Erdkunde"]
-};

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -6,8 +6,7 @@ import Constants from "expo-constants";
 import * as Sharing from "expo-sharing";
 import { get } from "react-native/Libraries/TurboModule/TurboModuleRegistry";
 var parseString = require("react-native-xml2js").parseString;
-import { exampleTags } from "./ExampleTags";
-
+import { subjectTags } from "./utils"; 
 
 
 const host = Constants?.expoConfig?.hostUri
@@ -60,8 +59,6 @@ export const getFolderContent = async (directory: string): Promise<FileListType 
                         }
                     }
                     else {
-                        //console.log(element["d:propstat"][0]["d:prop"][0]);
-
                         let tags: FileTagType[] = [];
                         if (element["d:propstat"][0]["d:prop"][0]["nc:system-tags"].length !== 0) {
                             if (element["d:propstat"][0]["d:prop"][0]["nc:system-tags"][0]["nc:system-tag"] !== undefined) {
@@ -72,9 +69,8 @@ export const getFolderContent = async (directory: string): Promise<FileListType 
                                     }
                                     tags.push(tagObject);
                                 });
-                            };
+                            }
                         }
-
 
                         let file: FileCardType = {
                             fileName: path.substring(path.lastIndexOf("/") + 1),
@@ -332,10 +328,10 @@ export const uploadFile = async (file: Blob, location: string): Promise<boolean 
                         }
 
                         // Assign tags based on directory path
-                        exampleTags['Subjects'].forEach((tag) => {
+                        subjectTags.forEach((tag: string) => {
                             if (directory_path.includes(tag)) {
                                 tags.forEach(async (systemTag: any) => {
-                                    if (systemTag.tagName === tag) {
+                                    if (directory_path.includes(tag)) {
                                         if (!(await assignSystemTag(fileID, systemTag))) {
                                             console.error("Failed to assign tag in Subject.");
                                         }
@@ -447,7 +443,7 @@ export const getAllSystemTags = async (): Promise<FileTagType[] | void> => {
     return tags;
 }
 
-export const getAllFilesOfSystemTag = async (tagID: number): Promise<FileCardType[] | void> => {
+export const getAllFilesBySystemTag = async (tagID: number): Promise<FileCardType[] | void> => {
     const requestHeaders = new Headers();
     requestHeaders.append("Content-Type", "text/plain");
     requestHeaders.append("Authorization", `Basic ${process.env.EXPO_PUBLIC_TOKEN}`);

--- a/app/utils/ServerRequests.tsx
+++ b/app/utils/ServerRequests.tsx
@@ -328,10 +328,10 @@ export const uploadFile = async (file: Blob, location: string): Promise<boolean 
                         }
 
                         // Assign tags based on directory path
-                        subjectTags.forEach((tag: string) => {
+                        subjectTags.forEach((tag) => {
                             if (directory_path.includes(tag)) {
                                 tags.forEach(async (systemTag: any) => {
-                                    if (directory_path.includes(tag)) {
+                                    if (systemTag.tagName === tag) {
                                         if (!(await assignSystemTag(fileID, systemTag))) {
                                             console.error("Failed to assign tag in Subject.");
                                         }

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -12,6 +12,7 @@ export enum LastModified {
 
 export const PERSONAL_SPACE_FOLDER_NAME = "Persönliche Ablage";
 
+export const subjectTags = [ "Mathe", "Deutsch", "Englisch", "Latein", "Physik", "Biologie", "Geschichte", "Erdkunde"];
 
 export function getTimeFrame(dateTimeString: string): LastModified {
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "expo-constants": "~16.0.2",
         "expo-document-picker": "~12.0.2",
         "expo-file-system": "~17.0.1",
+        "expo-image-picker": "~15.0.6",
+        "expo-intent-launcher": "^11.0.1",
         "expo-linking": "~6.3.1",
         "expo-router": "^3.5.16",
         "expo-sharing": "^12.0.1",
@@ -7917,6 +7919,33 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-15.0.6.tgz",
+      "integrity": "sha512-WckDXKlvOwywOr5twCOyqTDwEhYHD2ty6k8V2qCWbHHKEVe6C0iGFQgHHIPFKY4E1yhlEADg1UMTt0mnhV2A9Q==",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-intent-launcher": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/expo-intent-launcher/-/expo-intent-launcher-11.0.1.tgz",
+      "integrity": "sha512-nUmTTa/HG4jUyRc5YHngdpP5bMyGSRZPi2RX9kpILd3vbMWQeVnwzqAfC+uI34W8uKhEk+9b9Dytzmm7bBND1Q==",
       "peerDependencies": {
         "expo": "*"
       }


### PR DESCRIPTION
Closes #44 

Using this MR we can now display all tags that were assigned to a file on the FileCard. I also added a button that cab be used to filter for tags. If there can't be tags shown bc they dont exist or a NextCloud API doesn't return tag information (eg. the search API doesnt) we show the folder name where the tags would be.